### PR TITLE
Update image sample-statefulset.yaml

### DIFF
--- a/04-statefulset-pv/sample-statefulset.yaml
+++ b/04-statefulset-pv/sample-statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: registry.k8s.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.21
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
Failed to pull image "registry.k8s.io/nginx-slim:0.8": [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of registry.k8s.io/nginx-slim:0.8 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/